### PR TITLE
Feat: Added filtering by min and max price

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -4,6 +4,8 @@ class Api::V1::PostersController < ApplicationController
                           .sort_asc(params[:sort])
                           .sort_dsc(params[:sort])
                           .filter_by_name(params[:name])
+                          .filter_by_min_price(params[:min_price])
+                          .filter_by_max_price(params[:max_price])
     options = {}
     options[:meta] = {count: posters.length}
     render json: PosterSerializer.new(posters, options)

--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -2,4 +2,6 @@ class Poster < ApplicationRecord
   scope :sort_asc, -> (sort) {order(created_at: :asc) if sort=="asc"}
   scope :sort_dsc, -> (sort) {order(created_at: :desc) if sort=="desc"}
   scope :filter_by_name, -> (name) {where("name ILIKE '%#{name}%'") if name.present?}
+  scope :filter_by_min_price, -> (min_price) {where("price >= #{min_price}") if min_price.present?}
+  scope :filter_by_max_price, -> (max_price) {where("price <= #{max_price}") if max_price.present?}
 end


### PR DESCRIPTION
This PR introduces a refactor to the Api::V1::PostersController#index action to cleanly handle filtering and sorting logic by leveraging model scopes. The controller is now more concise, and all business logic for sorting and filtering has been moved to the Poster model.

Controller Refactor:

- Added calls to new scopes for filtering and sorting posters by name, min_price, max_price, and created_at in either ascending (asc) or descending (desc) order.
- Meta information (poster count) is included in the response to provide clients with additional context.

New Scopes in Poster Model:

- sort_asc: Orders posters by created_at in ascending order when the sort parameter is asc.
- sort_dsc: Orders posters by created_at in descending order when the sort parameter is desc.
- filter_by_name: Filters posters by a case-insensitive search for the name parameter.
- filter_by_min_price: Filters posters that have a price greater than or equal to the specified min_price.
- filter_by_max_price: Filters posters that have a price less than or equal to the specified max_price.