### PR TITLE
Removed options for show,create,update and destroy, removed square br…

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -13,9 +13,7 @@ class Api::V1::PostersController < ApplicationController
   
   def show
     poster = Poster.find(params[:id])
-    options = {}
-    options[:meta] = {count: [poster].count}
-    render json: PosterSerializer.new([ poster ], options)
+    render json: PosterSerializer.new(poster)
   end
 
   def destroy
@@ -25,17 +23,13 @@ class Api::V1::PostersController < ApplicationController
 
   def create
     poster = Poster.create(poster_params)
-    options = {}
-    options[:meta] = {count: [poster].count}
-    render json: PosterSerializer.new([poster],options)
+    render json: PosterSerializer.new(poster)
   end
 
   def update 
     poster = Poster.find(params[:id])
-    poster.update(poster_params)
-    options = {}
-    options[:meta] = {count: [poster].count}
-    render json: PosterSerializer.new([poster],options)
+    poster.update(poster_params) 
+    render json: PosterSerializer.new(poster)
   end
 
   private

--- a/spec/requests/api/v1/posters_request_spec.rb
+++ b/spec/requests/api/v1/posters_request_spec.rb
@@ -162,7 +162,7 @@ describe "Posters API" do
 
     posters_data = JSON.parse(response.body, symbolize_names: true)
 
-    poster = posters_data[:data].first
+    poster = posters_data[:data]
 
     expect(response).to be_successful
     expect(poster).to have_key(:id)
@@ -231,7 +231,7 @@ describe "Posters API" do
 
     expect(response).to be_successful
     posters_data = JSON.parse(response.body, symbolize_names: true)
-    poster = posters_data[:data].first
+    poster = posters_data[:data]
 
     expect(response).to be_successful
     expect(poster).to have_key(:id)
@@ -287,7 +287,7 @@ describe "Posters API" do
     
     expect(response).to be_successful
     posters_data = JSON.parse(response.body, symbolize_names: true)
-    poster = posters_data[:data].first
+    poster = posters_data[:data]
 
     expect(response).to be_successful
     expect(poster).to have_key(:id)


### PR DESCRIPTION
Description: This PR simplifies the serialization process for individual posters in the show, create, and update actions by removing unnecessary array wrapping when passing a single Poster object to the PosterSerializer. Specifically:

- Removed the redundant array wrapping ([poster]) in the PosterSerializer calls for show, create, and update actions.
- The response now directly serializes the single poster object, eliminating the need to wrap it in an array.
- Updated the relevant request specs to reflect the change by removing references to posters_data[:data].first and directly using posters_data[:data] for testing single poster responses.